### PR TITLE
add verbose configure-time flag references to some screen output

### DIFF
--- a/src/core/TC_kmodint.cpp
+++ b/src/core/TC_kmodint.cpp
@@ -184,7 +184,7 @@ TCKMI_getthermo9(char* singleword,
                  int* iread,
                  int* ierror);
 
-#define VERBOSE
+// #define VERBOSE
 
 //#include "TC_getthc9.c"
 
@@ -285,7 +285,7 @@ TC_kmodint_(char* mechfile, char* thermofile)
   /* Integer flags */
   int ierror, iread, ithermo, iremove;
 
-#ifdef VERBOSE
+#ifdef TCHEM_ENABLE_VERBOSE
   printf("\n");
   printf("       _                           _  _         _      \n");
   printf("      | | __ _ __ ___    ___    __| |(_) _ __  | |_    \n");
@@ -295,7 +295,7 @@ TC_kmodint_(char* mechfile, char* thermofile)
   printf("                                                       \n\n");
 #endif
 
-#ifdef VERBOSE
+#ifdef TCHEM_ENABLE_VERBOSE
   printf("Reading kinetic model from : %s\n", mechfile);
   printf("      and thermo data from : %s\n", thermofile);
 #endif
@@ -3391,7 +3391,7 @@ TCKMI_verifyreac(element* listelem,
 
   } /* Done outer loop */
 
-#ifdef VERBOSE
+#ifdef TCHEM_ENABLE_VERBOSE
   printf("!!! There are %d errors in the kinetic model \n", icount);
 #endif
 

--- a/src/core/TChem_KineticModelData.cpp
+++ b/src/core/TChem_KineticModelData.cpp
@@ -594,7 +594,9 @@ KineticModelData::initChem()
     printf("kmod.list : Error when interpreting kinetic model  !!!");
     exit(1);
   }
-  printf("kmod.list : %s\n", charvar4);
+  #ifdef TCHEM_ENABLE_VERBOSE
+    printf("kmod.list : %s\n", charvar4);
+  #endif
 
   fscanf(chemfile, "%d", &maxSpecInReac_);
   fscanf(chemfile, "%d", &maxTbInReac_);


### PR DESCRIPTION
This changes behavior in a couple of files to reference the cmake configure-time flag `TCHEM_ENABLE_VERBOSE` and silences some screen output when that flag is set to off.