### PR TITLE
set TCHEM_INSTALL_LIB_PATH to be an option that can be overridden at configure time

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,6 @@ IF (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   SET(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}" CACHE PATH "FOO install prefix" FORCE)
 ENDIF()
 
-SET(TCHEM_INSTALL_LIB_PATH     lib    )
 SET(TCHEM_INSTALL_INCLUDE_PATH include/tchem)
 SET(TCHEM_INSTALL_TEST_PATH    unit-test)
 SET(TCHEM_INSTALL_EXAMPLE_PATH example)
@@ -42,6 +41,9 @@ OPTION(OPENBLAS_INSTALL_PATH "Path to OpenBLAS installation")
 OPTION(KOKKOS_INSTALL_PATH "Path to Kokkos installation")
 OPTION(KOKKOSKERNELS_INSTALL_PATH "Path to KokkosKernels installation")
 OPTION(GTEST_INSTALL_PATH "Path to gtest installation")
+
+# option to manually set lib install path
+OPTION(TCHEM_INSTALL_LIB_PATH "Installation directory for libraries" lib)
 
 INCLUDE_DIRECTORIES(${TChem_BINARY_DIR})
 


### PR DESCRIPTION
The cmake variable `TCHEM_INSTALL_LIB_PATH` is currently hard-set to be `lib`, which causes some problems when we build in haero. Namely, it results in strife when building on linux systems that like `CMAKE_INSTALL_LIBDIR` to be `lib64`. Thus, this PR would allow the default `lib` to be overridden at configure time.