### PR TITLE
silence some screen prints in atmospheric chemistry

### DIFF
--- a/src/core/TChem_AtmosphericChemistry.cpp
+++ b/src/core/TChem_AtmosphericChemistry.cpp
@@ -422,7 +422,7 @@ AtmosphericChemistry::runHostBatch( /// thread block size
     auto species = root["species"];
     // 1. get number of batches or cells
     nBatch = pressure.size();
-    printf("Number of cells %d \n",nBatch );
+    // printf("Number of cells %d \n",nBatch );
     // 2. find species names
     std::vector<std::string> varnames;
     for (auto const& sp_cond : initial_state) {
@@ -436,7 +436,7 @@ AtmosphericChemistry::runHostBatch( /// thread block size
         if (strncmp(&speciesNamesHost(i, 0), (varnames[sp]).c_str(),
           LENGTHOFSPECNAME) == 0) {
           indx.push_back(i);
-          printf("species %s index %d \n", &speciesNamesHost(i, 0), i);
+          // printf("species %s index %d \n", &speciesNamesHost(i, 0), i);
           break;
         }
       }

--- a/src/core/TChem_KineticModelData.cpp
+++ b/src/core/TChem_KineticModelData.cpp
@@ -2168,7 +2168,9 @@ namespace TChem {
       }
 
     } else if (doc["NCAR-version" ] ){
-      printf("Using parser for NCAR atmospheric chemistry\n");
+      if(verboseEnabled) {
+        printf("Using parser for NCAR atmospheric chemistry\n");
+      }
       initChemNCAR(doc);
     } else {
       printf("we do not have a parser for this file\n");


### PR DESCRIPTION
Just some tiny changes to silence screen output in the atmospheric chemistry code.

I wrapped the one in [kmd.cpp](https://github.com/mschmidt271/TChem/blob/2ee88375d6e8c9b295f1ee7467f9f361b74a96c8/src/core/TChem_KineticModelData.cpp#L2172) in a verbose check, but [atmChem.cpp](https://github.com/mschmidt271/TChem/blob/2ee88375d6e8c9b295f1ee7467f9f361b74a96c8/src/core/TChem_AtmosphericChemistry.cpp) doesn't appear to have such flags, so I just commented them out.

@kyungjoo-kim @csafta @odiazib 