### PR TITLE
Fix memory leak in yaml chemical kinetics parsing

### DIFF
--- a/src/core/TChem_KineticModelData.cpp
+++ b/src/core/TChem_KineticModelData.cpp
@@ -3271,6 +3271,8 @@ int KineticModelData::initChemYaml(YAML::Node &doc,
       }
     }
 
+    free(periodictable);
+
     /* Range of temperatures for thermo fits */
     TthrmMin_ = 1.e-5;
     TthrmMax_ = 1.e+5;

--- a/src/core/TChem_KineticModelData.cpp
+++ b/src/core/TChem_KineticModelData.cpp
@@ -4137,7 +4137,6 @@ int KineticModelData::initChemYaml(YAML::Node &doc,
   StreamPrint(echofile, "%s \n", "kmod.reactions");
   for (auto const &reaction : gas_reactions) {
     auto equation = reaction["equation"].as<std::string>();
-    std::cout << equation <<"\n";
     StreamPrint(echofile, "%s ,\n",equation.c_str());
   }
  #if 0   


### PR DESCRIPTION
Hi!  This PR fixes a memory leak in the parsing of the yaml kinetic files and removes std::cout debug code.  Please let me know if you would like any changes.